### PR TITLE
Update contact information for UTAHMUG

### DIFF
--- a/topics/List_of_Model_User_Groups.md
+++ b/topics/List_of_Model_User_Groups.md
@@ -137,7 +137,7 @@ Contact: Jonathan Avner, Whitman, Requardt & Associates
 **Utah Model Users Group (UTAHMUG)**
 -------------------------------
 
-Contact: Natalia Brown, Utah Department of Transportation
+Contact: Bill Hereth, Wasatch Front Regional Council
 
 [Website](https://utahmug.org)
 


### PR DESCRIPTION
Bill Hereth is now chair of Model Users Group Executive Committee